### PR TITLE
Create min_face_size property

### DIFF
--- a/mtcnn/mtcnn.py
+++ b/mtcnn/mtcnn.py
@@ -202,6 +202,17 @@ class MTCNN(object):
             self.__onet = ONet(self.__session, False)
             self.__onet.set_weights(weights['ONet'])
 
+    @property
+    def min_face_size(self):
+        return self.__min_face_size
+    
+    @min_face_size.setter
+    def min_face_size(self, mfc=20):
+        try:
+            self.__min_face_size = int(mfc)
+        except ValueError:
+            self.__min_face_size = 20
+    
     def __compute_scale_pyramid(self, m, min_layer):
         scales = []
         factor_count = 0


### PR DESCRIPTION
The user may want to change the min_face_size variable depending on variables such as input image size or external conditions to speed up the process. This eliminate the need of multiple MTCNN instances.