### PR TITLE
Convert images to RGB in examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ The following example illustrates the ease of use of this package:
     >>> from mtcnn.mtcnn import MTCNN
     >>> import cv2
     >>>
-    >>> img = cv2.imread("ivan.jpg")
+    >>> img = cv2.cvtColor(cv2.imread("ivan.jpg"), cv2.COLOR_BGR2RGB)
     >>> detector = MTCNN()
     >>> print(detector.detect_faces(img))
     [{'box': [277, 90, 48, 63], 'keypoints': {'nose': (303, 131), 'mouth_right': (313, 141), 'right_eye': (314, 114), 'left_eye': (291, 117), 'mouth_left': (296, 143)}, 'confidence': 0.99851983785629272}]

--- a/example.py
+++ b/example.py
@@ -6,7 +6,7 @@ from mtcnn.mtcnn import MTCNN
 
 detector = MTCNN()
 
-image = cv2.imread("ivan.jpg")
+image = cv2.cvtColor(cv2.imread("ivan.jpg"), cv2.COLOR_BGR2RGB)
 result = detector.detect_faces(image)
 
 # Result is an array with all the bounding boxes detected. We know that for 'ivan.jpg' there is only one.


### PR DESCRIPTION
As mentioned in #36, and tested on my own data, the input to MTCNN should
be an image in RGB format. The OpenCV library load images as BGR and needs
to be converted.

Note that using the BGR format works okay for high-quality faces, as in the test
example image, but fails to detect more difficult (small, grainy, profile, ect.) faces.