### PR TITLE
OpenCV-python is not actually a pip dependency, as it can be installe…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,14 @@ or with `conda`
 
 Note that `tensorflow-gpu` version can be used instead if a GPU device is available on the system, which will speedup the results.
 
+Installing OpenCV-python can be done through
+
+.. code:: bash
+
+    $ pip install opencv-python>=4.1
+
+or it can be installed as part of the OpenCV installation, in the form of python bindings. 
+
 USAGE
 #####
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 keras>=2.0.0
-opencv-python>=4.1.0

--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,7 @@ setup(name='mtcnn',
       license='MIT',
       packages=setuptools.find_packages(exclude=["tests.*", "tests"]),
       install_requires=[
-          "keras>=2.0.0",
-          "opencv-python>=4.1.0"
+          "keras>=2.0.0"
       ],
       classifiers=[
           'Environment :: Console',


### PR DESCRIPTION
…d through the installation of OpenCV itself with bindings installed. In this case, it will not be seen by pip, but 'import cv2' will still work.

On our system, `opencv-python` is not installed through pip, yet `import cv2` works because the python bindings to the OpenCV library are installed as part of the library. 