### PR TITLE
Now you can use it as a library

### DIFF
--- a/mtcnn/network/factory.py
+++ b/mtcnn/network/factory.py
@@ -23,8 +23,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from tf.keras.layers import Input, Dense, Conv2D, MaxPooling2D, PReLU, Flatten, Softmax
-from tf.keras.models import Model
+from tensorflow.keras.layers import Input, Dense, Conv2D, MaxPooling2D, PReLU, Flatten, Softmax
+from tensorflow.keras.models import Model
 
 import numpy as np
 


### PR DESCRIPTION
This change allows this library to _actually be used as a library_ when installed through pip or conda.

When installing the library using pip I was unable to use it due to the fact that `tf` was undefined. I suspect that it was working locally for you within the project because you `import tensorflow as tf` elsewhere.

