### PR TITLE
use model() instead of model.predict()

### DIFF
--- a/mtcnn/mtcnn.py
+++ b/mtcnn/mtcnn.py
@@ -339,7 +339,8 @@ class MTCNN(object):
             img_x = np.expand_dims(scaled_image, 0)
             img_y = np.transpose(img_x, (0, 2, 1, 3))
 
-            out = self._pnet.predict(img_y)
+            out = self._pnet(img_y, training=False)
+            out = [tensor_element.numpy() for tensor_element in out]
 
             out0 = np.transpose(out[0], (0, 2, 1, 3))
             out1 = np.transpose(out[1], (0, 2, 1, 3))
@@ -407,7 +408,8 @@ class MTCNN(object):
         tempimg = (tempimg - 127.5) * 0.0078125
         tempimg1 = np.transpose(tempimg, (3, 1, 0, 2))
 
-        out = self._rnet.predict(tempimg1)
+        out = self._rnet(tempimg1, training=False)
+        out = [tensor_element.numpy() for tensor_element in out]
 
         out0 = np.transpose(out[0])
         out1 = np.transpose(out[1])
@@ -463,7 +465,8 @@ class MTCNN(object):
         tempimg = (tempimg - 127.5) * 0.0078125
         tempimg1 = np.transpose(tempimg, (3, 1, 0, 2))
 
-        out = self._onet.predict(tempimg1)
+        out = self._onet(tempimg1, training=False)
+        out = [tensor_element.numpy() for tensor_element in out]
         out0 = np.transpose(out[0])
         out1 = np.transpose(out[1])
         out2 = np.transpose(out[2])


### PR DESCRIPTION
when using model.predict() on small batches it is verry slow.
Alternatively you can call the model directly with the training=False flag which is way faster.
the predict method does assemble batches and other things. since you are calling the model for every frame seperately batching does not give you anny advantag.
calling it directly gives you back a tensor, so you need to convert them into numpy arrays with .numpy()
makes your model quite a bit faster for no harm!