### PR TITLE
in setuptools 69 cant import setuptools from setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@
 # SOFTWARE.
 
 import sys
-from setuptools import setup, setuptools
+from setuptools import setup, find_packages
 
 
 __author__ = "Iván de Paz Centeno"
@@ -48,7 +48,7 @@ setup(name='mtcnn',
       author='Iván de Paz Centeno',
       author_email='ipazc@unileon.es',
       license='MIT',
-      packages=setuptools.find_packages(exclude=["tests.*", "tests"]),
+      packages=find_packages(exclude=["tests.*", "tests"]),
       install_requires=[
           "keras>=2.0.0",
           "opencv-python>=4.1.0"


### PR DESCRIPTION
in setuptools 69 i get this error

```
ImportError: cannot import name 'setuptools' from 'setuptools' (/nix/store/f3qdwzblc4p7as5p46zhmh7f48xa62c8-python3.10-
setuptools-69.1.1/lib/python3.10/site-packages/setuptools/__init__.py)
```
